### PR TITLE
cloud-user-data/k3s.sh: provision server with https://k3s.io/ installed

### DIFF
--- a/cloud-user-data/k3s.sh
+++ b/cloud-user-data/k3s.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# Ref: https://k3s.io/
+#
+# https://my.vultr.com/ -> Orchestration -> Scripts
+#   - Script Name ...... k3s
+#   - Type ............. Boot
+#   - Script ........... this file
+#
+# Server ref:
+#   - Shared CPU ....... vc2-1c-2gb
+#   - Cores ............ 1 vCPU
+#   - Memory ........... 2 GB
+#   - Storage .......... 55 GB
+#   - Price ............ $10.00/month ($0.014/hr)
+#   - OS ............... Debian 13 x64
+#   - Startup Script ... k3s
+#
+# Output:
+#   - /var/log/cloud-init-output.log
+#   - /var/log/cloud-init.log
+#
+
+set -x
+set -e
+apt update
+apt install -y tmux htop
+curl -sfL https://get.k3s.io | bash -
+ufw allow 6443/tcp


### PR DESCRIPTION
It's done:

- **cloud-user-data/k3s.sh** has been created
- [Vultr](https://vultr.com) server provisioned using it as a **Startup Script**
- It works fine and [K3s](https://k3s.io/) is installed