### PR TITLE
dashboard/delete.sh: created to delete kubernetes-dashboard namespace

### DIFF
--- a/dashboard/delete.sh
+++ b/dashboard/delete.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -x
+kubectl delete namespaces kubernetes-dashboard
+{ set +x; } 2>/dev/null
+


### PR DESCRIPTION
It's done:

- **dashboard/delete.sh** has been created
- Code won't be rearranged