### PR TITLE
postgres: '.helmignore' copied from 'helm create postgres' generated folder

### DIFF
--- a/postgres/.helmignore
+++ b/postgres/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/


### PR DESCRIPTION
It's done:

- `helm create postgres` → `.helmignore` has been copied
- That's enough for now provided that `helm package .` generates **postgres-0.1.0.tgz** as expected