### PR TITLE
flatcar: docker-flatcar and containerd-flatcar extensions disabled

### DIFF
--- a/flatcar/k3s.yaml
+++ b/flatcar/k3s.yaml
@@ -29,6 +29,15 @@ storage:
           REBOOT_WINDOW_START=01:30
           REBOOT_WINDOW_LENGTH=1h
       mode: 0420
+  # https://www.flatcar.org/docs/latest/provisioning/sysext/
+  # Remove Docker and Containerd from Flatcar
+  links:
+    - path: /etc/extensions/docker-flatcar.raw
+      target: /dev/null
+      overwrite: true
+    - path: /etc/extensions/containerd-flatcar.raw
+      target: /dev/null
+      overwrite: true
 
 passwd:
   users:


### PR DESCRIPTION
It's done: both **docker-flatcar** and **contained-flatcar** extensions have been disabled. This is the result:
```
core@fc5 ~ $ ls -l /etc/extensions 
total 0
lrwxrwxrwx. 1 root root 9 Nov 30 09:00 containerd-flatcar.raw -> /dev/null
lrwxrwxrwx. 1 root root 9 Nov 30 09:00 docker-flatcar.raw -> /dev/null
```